### PR TITLE
clean API responses before passing to map 🧼

### DIFF
--- a/frank.js
+++ b/frank.js
@@ -1,5 +1,7 @@
-mapboxgl.accessToken =
-  "pk.eyJ1IjoiamxvZXdlbiIsImEiOiJja2xndmR4bTQ1NXcxMnZ1aXNqaWo4ZHpyIn0.8dx0t2m15JltIuCf25x7FA";
+mapboxgl.accessToken = "pk.eyJ1IjoiamxvZXdlbiIsImEiOiJja2xndmR4bTQ1NXcxMnZ1aXNqaWo4ZHpyIn0.8dx0t2m15JltIuCf25x7FA";
+  
+const dataUrl = "https://json-loewen-sundown-towns.pantheonsite.io/sundown/database/geojson.php?";
+
 var map = new mapboxgl.Map({
   container: "map",
   style: "mapbox://styles/jloewen/cklgvceam6dr117rz6clq3pf1",
@@ -13,8 +15,17 @@ var map = new mapboxgl.Map({
   ],
 });
 
-let dataUrl =
-  "https://json-loewen-sundown-towns.pantheonsite.io/sundown/database/geojson.php?";
+function fetchCleanData(url) {
+  return fetch(url)
+    .then((response) => response.text())
+    .then((text) => {
+      // This is necessary because some API responses include 
+      // munged up database warnings
+      const cleanResponse = text.slice(text.indexOf('{'));
+      return JSON.parse(cleanResponse);
+    });
+}
+
 
 map.addControl(
   new MapboxGeocoder({
@@ -27,16 +38,18 @@ map.addControl(
 var nav = new mapboxgl.NavigationControl();
 map.addControl(nav, "top-left");
 
-map.on("load", function () {
+map.on("load", async function () {
   var legendEl = document.getElementById("legend");
   legendEl.addEventListener("click", function (e) {
     var value = e.target.innerHTML;
     filterMarkers(value);
   });
 
+  const townData = await fetchCleanData(dataUrl);
+
   map.addSource("towns-data", {
     type: "geojson",
-    data: dataUrl,
+    data: townData,
   });
 
   map.addLayer(

--- a/map.js
+++ b/map.js
@@ -14,6 +14,17 @@ const confirmedDescription = {
   9: 'Black Town or Township'
 };
 
+function fetchCleanData(url) {
+  return fetch(url)
+    .then((response) => response.text())
+    .then((text) => {
+      // This is necessary because some API responses include 
+      // munged up database warnings
+      const cleanResponse = text.slice(text.indexOf('{'));
+      return JSON.parse(cleanResponse);
+    });
+}
+
 function filterMarkers(status) {
   // if clear is clicked, remove filter, otherwise filter by status
   if (status === 'Clear filter') {
@@ -58,10 +69,13 @@ map.addControl(
   'top-left'
 );
 
-map.on('load', function () {
+map.on('load', async function () {
+
+  const townData = await fetchCleanData(dataUrl); 
+
   map.addSource('towns-data', {
     type: 'geojson',
-    data: dataUrl,
+    data: townData
   });
 
   map.addLayer(


### PR DESCRIPTION
Previously, we have seen that the GeoJSON's API response might be erroneously prepended by a database warning (ref. https://github.com/samfader/sundown-towns/issues/1#issuecomment-802309759). This would cause the application to trip up and not properly add the expected map data whenever the database appeared to be under moderate load. 

This change ensures we are removing any prepended messages before attempting to parse the GeoJSON response, and should therefore ensure better uptime for data being overlayed on top of the map.

cc/ @samfader﻿
